### PR TITLE
Add default argument for ObservabilityScope

### DIFF
--- a/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
+++ b/Sources/PackageCollectionsSigning/PackageCollectionSigning.swift
@@ -95,7 +95,7 @@ public struct PackageCollectionSigning: PackageCollectionSigner, PackageCollecti
 
     private let observabilityScope: ObservabilityScope
 
-    public init(trustedRootCertsDir: URL? = nil, additionalTrustedRootCerts: [String]? = nil, observabilityScope: ObservabilityScope, callbackQueue: DispatchQueue) {
+    public init(trustedRootCertsDir: URL? = nil, additionalTrustedRootCerts: [String]? = nil, observabilityScope: ObservabilityScope = .silent, callbackQueue: DispatchQueue) {
         self.trustedRootCertsDir = trustedRootCertsDir
         self.additionalTrustedRootCerts = additionalTrustedRootCerts.map { $0.compactMap {
             guard let data = Data(base64Encoded: $0) else {
@@ -293,5 +293,11 @@ public enum PackageCollectionSigningError: Error, Equatable {
 private extension PackageCollectionModel.V1.Signature.Certificate.Name {
     init(from name: CertificateName) {
         self.init(userID: name.userID, commonName: name.commonName, organizationalUnit: name.organizationalUnit, organization: name.organization)
+    }
+}
+
+public extension ObservabilityScope {
+    static var silent: ObservabilityScope {
+        ObservabilitySystem { _, _ in }.topScope
     }
 }


### PR DESCRIPTION
@yim-lee, I'm opening this up as a draft PR in my repo for discussion how best to address the following issue:

I'm trying to sign a collection from SPI but in order to instantiate `PackageCollectionSigning`, I need to pass in an `ObservabilityScope`. This lives in `Basics` and it's not a library I can import into SPI because it's not exposed as a product, at least as far as I can tell.

My current workaround is to simply "default away" the parameter but that's probably only a workaround we could maintain in a fork for the time being.

Would it be possible to either add an overload that doesn't include the inaccessible symbol or make `ObservabilityScope` available to clients in some way?